### PR TITLE
fix: update package manager version to pnpm@10.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "optionalDependencies": {
         "canvas": "^2.11.2"
     },
-    "packageManager": "pnpm@8.7.6",
+    "packageManager": "pnpm@10.11.0",
     "dependencies": {
         "sharp": "^0.33.5"
     }


### PR DESCRIPTION
pnpm in version 8 do not support catalog features, which are currently used for grouping eslint pacakges. It was added in version 9.5.0

More info about feature:
- https://pnpm.io/catalogs
- https://antfu.me/posts/categorize-deps

As result during `pnpm install` error is raised:

```
pnpm install
Scope: all 4 workspace projects
 ERR_PNPM_SPEC_NOT_SUPPORTED_BY_ANY_RESOLVER  @eslint/js@catalog:lint isn't supported by any available resolver.

This error happened while installing a direct dependency of /home/dabomian/Dev/creoox/sdk
Progress: resolved 18, reused 16, downloaded 1, added 0
```

